### PR TITLE
Exclude own uploads from Snatched list. Closes #23

### DIFF
--- a/sections/torrents/download.php
+++ b/sections/torrents/download.php
@@ -77,7 +77,7 @@ if (!is_array($Info) || !array_key_exists('PlainArtists', $Info) || empty($Info[
 			t.Size,
 			t.FreeTorrent,
 			t.info_hash,
-			t.UserID,
+			t.UserID
 		FROM torrents AS t
 			INNER JOIN torrents_group AS tg ON tg.ID = t.GroupID
 		WHERE t.ID = '".db_string($TorrentID)."'");

--- a/sections/torrents/download.php
+++ b/sections/torrents/download.php
@@ -76,7 +76,8 @@ if (!is_array($Info) || !array_key_exists('PlainArtists', $Info) || empty($Info[
 			tg.CategoryID,
 			t.Size,
 			t.FreeTorrent,
-			t.info_hash
+			t.info_hash,
+			t.UserID,
 		FROM torrents AS t
 			INNER JOIN torrents_group AS tg ON tg.ID = t.GroupID
 		WHERE t.ID = '".db_string($TorrentID)."'");
@@ -92,7 +93,7 @@ if (!is_array($Info) || !array_key_exists('PlainArtists', $Info) || empty($Info[
 if (!is_array($Info[0])) {
 	error(404);
 }
-list($Media, $Format, $Encoding, $Year, $GroupID, $Name, $Image, $CategoryID, $Size, $FreeTorrent, $InfoHash) = array_shift($Info); // used for generating the filename
+list($Media, $Format, $Encoding, $Year, $GroupID, $Name, $Image, $CategoryID, $Size, $FreeTorrent, $InfoHash, $TorrentUploaderID) = array_shift($Info); // used for generating the filename
 $Artists = $Info['Artists'];
 
 // If he's trying use a token on this, we need to make sure he has one,
@@ -154,7 +155,7 @@ if ($_REQUEST['usetoken'] && $FreeTorrent == '0') {
 }
 
 //Stupid Recent Snatches On User Page
-if ($CategoryID == '1' && $Image != '') {
+if ($CategoryID == '1' && $Image != '' && $TorrentUploaderID != $UserID) {
 	$RecentSnatches = $Cache->get_value("recent_snatches_$UserID");
 	if (!empty($RecentSnatches)) {
 		$Snatch = array(

--- a/sections/user/user.php
+++ b/sections/user/user.php
@@ -734,6 +734,7 @@ if (check_paranoia_here('snatched')) {
 				INNER JOIN torrents AS t ON t.ID = s.fid
 				INNER JOIN torrents_group AS g ON t.GroupID = g.ID
 			WHERE s.uid = '$UserID'
+				AND t.UserID != '$UserID'
 				AND g.CategoryID = '1'
 				AND g.WikiImage != ''
 			GROUP BY g.ID


### PR DESCRIPTION
Gazelle automatically adds downloaded ([DL]) torrents to recently snatched list. Users have to redownload torrents after uploading, which adds the torrent to their recently snatched. This prevents that from happening. #5 edited `sections/user/user.php`, but that is not necessary. Torrents are not added to xbt_snatched unless client announces complete transfer, and when that happens the torrent should be in recent snatches.