### PR TITLE
Making the 2FA code display as plaintext

### DIFF
--- a/sections/user/2fa/step1.php
+++ b/sections/user/2fa/step1.php
@@ -28,7 +28,7 @@ View::show_header('Two-factor Authentication');
 						->get('png')
 				);
 			?>">
-            <div style="display: none">Secret Text: <span><?=$_SESSION['private_key']?></span></div>
+            Secret Text: <span><?=$_SESSION['private_key']?></span>
 
 			<? if(isset($_GET['invalid'])): ?>
 				<p class="warning">Please ensure you've imported the correct key into your authentication app and try again.</p>


### PR DESCRIPTION
The 2FA code only appears in the png image. This change makes the code appear as plaintext for ease of use.