### PR TITLE
Replace 'random' with 'posts' in the menubar

### DIFF
--- a/design/privateheader.php
+++ b/design/privateheader.php
@@ -292,9 +292,9 @@ if (check_perms('site_send_unlimited_invites')) {
 					<li id="nav_better"<?=
 						Format::add_class($PageID, array('better'), 'active', true)?>>
 						<a href="better.php">Better</a></li>
-					<li id="nav_random"<?=
+					<li id="nav_posts"<?=
 						Format::add_class($PageID, array('random'), 'active', true)?>>
-						<a href="random.php">Random Album</a></li>
+						<a href="userhistory.php?action=posts">Posts</a></li>
 					<li id="nav_logchecker" style="display: none"<?=
 						Format::add_class($PageID, array('logchecker'), 'active', true)?>>
 						<a href="logchecker.php">Log Checker</a></li>


### PR DESCRIPTION
I've tested this in several stylesheets. First adding an item broke some stylesheets, but replacing it does not.