### PR TITLE
Fixed primary violation when seeding users

### DIFF
--- a/db/seeds/InitialUserSeeder.php
+++ b/db/seeds/InitialUserSeeder.php
@@ -71,7 +71,7 @@ class InitialUserSeeder extends AbstractSeed {
                 'Uploaded' => STARTING_UPLOAD
             ],
             [
-                'UserID' => $adminId,
+                'UserID' => $userId,
                 'Uploaded' => STARTING_UPLOAD
             ]
         ])->saveData();


### PR DESCRIPTION
There's a typo in the code that caused the creation of default admin and user account to fail.