### PR TITLE
Fixed a typo in the header search bars

### DIFF
--- a/templates/index/private-header.twig
+++ b/templates/index/private-header.twig
@@ -133,7 +133,7 @@
     <li id="searchbar_collages">
         <span class="hidden">Collage: </span>
         <form class="search_form" name="artists" action="collage.php" method="get">
-            <input id="collagesearch" value="Collages" placeholder="Collage" type="text" name="search" size="17" spellcheck="false" accesskey="c" />
+            <input id="collagesearch" value="Collages" placeholder="Collages" type="text" name="search" size="17" spellcheck="false" accesskey="c" />
         </form>
     </li>
     <li id="searchbar_requests">


### PR DESCRIPTION
When you focus on the "Collages" search bar, it changes to "Collage".