### PR TITLE
Only witness news when newsReader returns non-null

### DIFF
--- a/sections/index/private.php
+++ b/sections/index/private.php
@@ -9,7 +9,7 @@ $torMan     = new Gazelle\Manager\Torrent;
 $userMan    = new Gazelle\Manager\User;
 $viewer     = new Gazelle\User($LoggedUser['ID']);
 
-if ($newsReader->lastRead($LoggedUser['ID']) < $newsMan->latestId()) {
+if (!is_null($newsReader->lastRead($LoggedUser['ID'])) && $newsReader->lastRead($LoggedUser['ID']) < $newsMan->latestId()) {
     $newsReader->witness($LoggedUser['ID']);
 }
 


### PR DESCRIPTION
When initially startup, the lastRead new ID will be null, if we don't check nullness, which will result in inserting a row with news id = null