### PR TITLE
Fix a typo in the access settings

### DIFF
--- a/templates/user/setting/access.twig
+++ b/templates/user/setting/access.twig
@@ -92,7 +92,7 @@
         <td class="label"><strong>API Keys</strong></td>
         <td>API keys can be generated to access our
             <b><a href="https://github.com/OPSnet/Gazelle/wiki/JSON-API-Documentation" target='_blank'>API</a></b>.<br />
-            Rememeber to revoke tokens you no longer use.<br />
+            Remember to revoke tokens you no longer use.<br />
             <strong class="important_text">Treat your tokens like passwords and keep them secret.</strong>
             <br /><br />
 {%- for token in user.apiTokenList %}


### PR DESCRIPTION
In the API keys section: `Rememeber` -> `Remember`