### PR TITLE
Adds releaseTags Cue/Log/100 for CD uploads

### DIFF
--- a/app/Notification/Upload.php
+++ b/app/Notification/Upload.php
@@ -298,7 +298,14 @@ class Upload extends \Gazelle\Base {
 
     public function ircNotification(): string {
         $torrent = $this->torrent;
-        $tgroup  = $torrent->group();
+	$tgroup  = $torrent->group();
+	$releaseTags = [$torrent->media(), $torrent->format(), $torrent->encoding()];
+	/**
+	 * For CD media it publishes whether there is a Cue, Log, and Score. This can be used by tools like autobrr
+	 */
+	if (strcmp($torrent->media(), "CD") == 0) {
+		array_push($releaseTags, $torrent->hasCue() ? "Cue": "", $torrent->hasLog() ? "Log" : "", $torrent->logScore()); 
+	}
         return match ($tgroup->categoryName()) {
             'Music' => Irc::render(
                 IrcText::Bold,
@@ -313,7 +320,7 @@ class Upload extends \Gazelle\Base {
                 '[',
                 $torrent->isRemasteredUnknown() || !$torrent->isRemastered() ? $tgroup->year() : $torrent->remasterYear(),
                 "] [{$tgroup->releaseTypeName()}] ",
-                implode('/', [$torrent->media(), $torrent->format(), $torrent->encoding()]),
+                $torrent->implode('/', $releaseTags),
                 IrcText::ColorOff,
                 ' – ',
                 IrcText::SurfieGreen,


### PR DESCRIPTION
This can be used by popular tools like autobrr that listen the IRC announce channel, and let user define rules based on type of media, quality, cue, log presence and score. 
Currently, RED publishes this information, but not OPS.

For not CD media the release tags are kept the same.
```
TORRENT: Mr. Music – Best Mr. Music – [2008] [Album] WEB/FLAC/Lossless – heavy.metal,pop,jazz,classical – https://URL/torrents.php?id=12345 – https://URLtorrents.php?id=12345&torrentid=12345&action=download
```
For CD media uploads the release tags in the announcement would look like this:

```
TORRENT: Mr. Music – Best Mr. Music – [2008] [Album] CD/FLAC/Lossless/Cue/Log/90 – heavy.metal,pop,jazz,classical – https://URL/torrents.php?id=12345 – https://URLtorrents.php?id=12345&torrentid=12345&action=download
```