### PR TITLE
Update top10 API docs

### DIFF
--- a/docs/07-API.md
+++ b/docs/07-API.md
@@ -272,21 +272,21 @@ If the request is invalid, or a problem occurs, the `status` will be `failure`. 
 
 **URL:** `ajax.php?action=top10`
 
-**Arguments**
+### Arguments
 
-### `type`
+#### `type`
 Specifies the type of top 10 list to retrieve. This parameter can be one of the following values:
 
 - `torrents` (Default)
 - `users`
 - `tags`
 
-### `details`
+#### `details`
 Specifies the details for the selected `type`. The available options vary depending on the value of `type`.
 
 - `all`: Lists all categories for the selected type (Default)
 
-#### When `type` = "torrents":
+##### When `type` = "torrents":
 - `day`: Most Active Torrents Uploaded in the Past Day
 - `week`: Most Active Torrents Uploaded in the Past Week
 - `month`: Most Active Torrents Uploaded in the Past Month
@@ -296,21 +296,21 @@ Specifies the details for the selected `type`. The available options vary depend
 - `data`: Most Data Transferred Torrents
 - `seeded`: Best Seeded Torrents
 
-#### When `type` = "users":
+##### When `type` = "users":
 - `ul`: Uploaders
 - `dl`: Downloaders
 - `numul`: Torrents Uploaded
 - `uls`: Fastest Uploaders
 - `dls`: Fastest Downloaders
 
-#### When `type` = "tags":
+##### When `type` = "tags":
 - `ut`: Most Used Torrent Tags
 - `ur`: Most Used Request Tags
 - `v`: Most Highly Voted Tags
 
-### `limit`
+#### `limit`
 
-Specifies the maximum number of results to return per category. Must be one of ["10", "100", "250"]. When `type`="torrents" and `details`="all", only `limit`="100" is permitted.
+Specifies the maximum number of results to return per category. Must be one of 10 (default), 100 or 250. When `type`="torrents" and `details`="all", only `limit`="10" is permitted.
 
 ## Example Requests
 

--- a/docs/07-API.md
+++ b/docs/07-API.md
@@ -274,19 +274,18 @@ If the request is invalid, or a problem occurs, the `status` will be `failure`. 
 
 ### Arguments
 
-#### `type`
-Specifies the type of top 10 list to retrieve. This parameter can be one of the following values:
+#### `type` - Specifies the type of top 10 list to retrieve
 
 - `torrents` (Default)
 - `users`
 - `tags`
 
-#### `details`
-Specifies the details for the selected `type`. The available options vary depending on the value of `type`.
+#### `details` - Category for the selected `type`. The available options vary depending on the value of `type`
 
 - `all`: Lists all categories for the selected type (Default)
 
 ##### When `type` = "torrents":
+
 - `day`: Most Active Torrents Uploaded in the Past Day
 - `week`: Most Active Torrents Uploaded in the Past Week
 - `month`: Most Active Torrents Uploaded in the Past Month
@@ -297,6 +296,7 @@ Specifies the details for the selected `type`. The available options vary depend
 - `seeded`: Best Seeded Torrents
 
 ##### When `type` = "users":
+
 - `ul`: Uploaders
 - `dl`: Downloaders
 - `numul`: Torrents Uploaded
@@ -304,13 +304,14 @@ Specifies the details for the selected `type`. The available options vary depend
 - `dls`: Fastest Downloaders
 
 ##### When `type` = "tags":
+
 - `ut`: Most Used Torrent Tags
 - `ur`: Most Used Request Tags
 - `v`: Most Highly Voted Tags
 
-#### `limit`
+#### `limit` - The maximum number of results to return per category. 
 
-Specifies the maximum number of results to return per category. Must be one of 10 (default), 100 or 250. When `type`="torrents" and `details`="all", only `limit`="10" is permitted.
+Must be one of 10 (default), 100 or 250. When `type`="torrents" and `details`="all", only `limit`="10" is permitted.
 
 ## Example Requests
 

--- a/docs/07-API.md
+++ b/docs/07-API.md
@@ -270,14 +270,52 @@ If the request is invalid, or a problem occurs, the `status` will be `failure`. 
 
 ## Top 10
 
-**URL:**
-`ajax.php?action=top10`
+**URL:** `ajax.php?action=top10`
 
-**Arguments:**
+**Arguments**
 
-`type` - one of: torrents, tags, users (default: torrents)
+### `type`
+Specifies the type of top 10 list to retrieve. This parameter can be one of the following values:
 
-`limit` - one of 10, 100, 250 (default: 10)
+- `torrents` (Default)
+- `users`
+- `tags`
+
+### `details`
+Specifies the details for the selected `type`. The available options vary depending on the value of `type`.
+
+- `all`: Lists all categories for the selected type (Default)
+
+#### When `type` = "torrents":
+- `day`: Most Active Torrents Uploaded in the Past Day
+- `week`: Most Active Torrents Uploaded in the Past Week
+- `month`: Most Active Torrents Uploaded in the Past Month
+- `year`: Most Active Torrents Uploaded in the Past Year
+- `overall`: Most Active Torrents Uploaded of All Time
+- `snatched`: Most Snatched Torrents
+- `data`: Most Data Transferred Torrents
+- `seeded`: Best Seeded Torrents
+
+#### When `type` = "users":
+- `ul`: Uploaders
+- `dl`: Downloaders
+- `numul`: Torrents Uploaded
+- `uls`: Fastest Uploaders
+- `dls`: Fastest Downloaders
+
+#### When `type` = "tags":
+- `ut`: Most Used Torrent Tags
+- `ur`: Most Used Request Tags
+- `v`: Most Highly Voted Tags
+
+### `limit`
+
+Specifies the maximum number of results to return per category. Must be one of ["10", "100", "250"]. When `type`="torrents" and `details`="all", only `limit`="100" is permitted.
+
+## Example Requests
+
+### Example 1: Top 10 Torrents of the Week
+
 
 **Response format:**
 


### PR DESCRIPTION
top10 API docs don't currently include the `details` parameter or its possible values.
Quick PR to include those :)